### PR TITLE
allow usage without `::` syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ You can still use `curry-this` without the experimental syntax
 
 ```js
 const add = (a, b) => a + b;
-const curriedAdd = curry.call(add);
+const curriedAdd = curry(add);
 
 curriedAdd(1)(2); //» 3
 ```

--- a/module/curry.js
+++ b/module/curry.js
@@ -20,7 +20,7 @@ export default ({ placeholder }) => {
     args.some(arg => arg === placeholder);
 
   function curry(...initialArgs) {
-    const fn = this;
+    const fn = typeof this === 'function' ? this : initialArgs.shift();
     const len = containsPlaceholder(initialArgs) ? initialArgs.length : fn.length;
 
     const _curry = (...args) => {

--- a/test/es-2016.js
+++ b/test/es-2016.js
@@ -84,3 +84,27 @@ test(title(
 
   end();
 });
+
+test(title(
+      'Has a none experimental API'
+), ({equal, end}) => {
+  equal(
+    curry(wrap, _, '<', '>')('hello'),
+    '<hello>',
+    'with one placeholder'
+  );
+
+  equal(
+    curry(wrap, _, '?')('hello'),
+    '?hello!',
+    'with one placeholder'
+  );
+
+  equal(
+    curry(wrap, _, _, _)('hello')('<')('>'),
+    '<hello>',
+    'with only placeholder'
+  );
+
+  end();
+});


### PR DESCRIPTION
We removed this before, but sometimes it would be nice if we could use this without the experimental `::` syntax and without `call`. I don't see a problem with adding this again and it's just one ternary.

Opinions @hemanth @davidchase @hemanth ?