### PR TITLE
Minor placeholder cleanup.

### DIFF
--- a/module.js
+++ b/module.js
@@ -1,4 +1,9 @@
 import curryFunction from './module/curry';
 
-export const _ = {};
+// The placeholder could be any uniquely identifiable object.
+// Its contents are irrelevant.
+// We provide it with a `placeholder` property only to make it easier to
+// see what it is in a debugger window, for example.
+export const _ = {placeholder: 'curry-this'};
+
 export const curry = curryFunction({placeholder: _});

--- a/module.js
+++ b/module.js
@@ -1,5 +1,4 @@
-import placeholder from './module/_';
 import curryFunction from './module/curry';
 
-export const _ = placeholder({Symbol});
+export const _ = {};
 export const curry = curryFunction({placeholder: _});

--- a/module/_.js
+++ b/module/_.js
@@ -1,3 +1,0 @@
-import symbol from 'es6-symbol';
-
-export default () => symbol('__CURRY-THIS-PLACEHOLDER__');

--- a/module/index.js
+++ b/module/index.js
@@ -1,4 +1,9 @@
 import curryFunction from './curry';
 
-export const _ = {};
+// The placeholder could be any uniquely identifiable object.
+// Its contents are irrelevant.
+// We provide it with a `placeholder` property only to make it easier to
+// see what it is in a debugger window, for example.
+export const _ = {placeholder: 'curry-this'};
+
 export const curry = curryFunction({placeholder: _});

--- a/module/index.js
+++ b/module/index.js
@@ -1,6 +1,4 @@
-import placeholder from './_';
 import curryFunction from './curry';
 
-export const _ = placeholder();
+export const _ = {};
 export const curry = curryFunction({placeholder: _});
-

--- a/package.json
+++ b/package.json
@@ -56,7 +56,6 @@
     "tape-catch": "1.0.4"
   },
   "dependencies": {
-    "es6-symbol": "^3.0.0",
     "util-arity": "^1.0.0"
   }
 }


### PR DESCRIPTION
No need to use a symbol here--just use a unique object.
Saves us a dependency and a file.

This commit has no effect on user-visible functionality.
Unit tests pass.